### PR TITLE
fix: set version and description for flox build

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -34,7 +34,11 @@
       "tracelinks": {
         "command": "  make\n  make test\n  make install PREFIX=$out\n",
         "runtime-packages": [],
-        "sandbox": "pure"
+        "sandbox": "pure",
+        "version": {
+          "command": "git describe --tags --always --dirty"
+        },
+        "description": "Report on symbolic links encountered in path traversals"
       }
     }
   },

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -25,6 +25,8 @@ on-activate = '''
 [build]
 tracelinks.sandbox = "pure"
 tracelinks.runtime-packages = []
+tracelinks.version.command = "git describe --tags --always --dirty"
+tracelinks.description = "Report on symbolic links encountered in path traversals"
 tracelinks.command = '''
   make
   make test


### PR DESCRIPTION
Set description and dynamically detect the version using `git describe` when performing the flox build.